### PR TITLE
Allow unicode text input

### DIFF
--- a/src/textual_inputs/text_input.py
+++ b/src/textual_inputs/text_input.py
@@ -1,7 +1,6 @@
 """
 Simple text input
 """
-import string
 from typing import Any, List, Optional, Tuple, Union
 
 import rich.box

--- a/src/textual_inputs/text_input.py
+++ b/src/textual_inputs/text_input.py
@@ -240,7 +240,7 @@ class TextInput(Widget):
                     )
             await self._emit_on_change(event)
 
-        elif event.key in string.printable:
+        elif len(event.key) == 1 and event.key.isprintable():
             if self._cursor_position == 0:
                 self.value = event.key + self.value
             elif self._cursor_position == len(self.value):


### PR DESCRIPTION
The `TextInput` widget was ignoring any non-ascii characters such as "🙂" or "å". I fixed it by using `str.isprintable()` instead of `string.printable`.