### PR TITLE
fix: patch message handler example

### DIFF
--- a/examples/simple_form.py
+++ b/examples/simple_form.py
@@ -134,10 +134,10 @@ password: {"".join("•" for _ in self.password.value)}
         self.current_index = -1
         await self.header.focus()
 
-    async def message_input_on_change(self, message) -> None:
+    async def handle_input_on_change(self, message) -> None:
         self.log(f"Input: {message.sender.name} changed")
 
-    async def message_input_on_focus(self, message) -> None:
+    async def handle_input_on_focus(self, message) -> None:
         self.current_index = self.tab_index.index(message.sender.name)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-textual==0.1.10
+textual==0.1.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    textual >= 0.1.10,< 0.2
+    textual >= 0.1.11,< 0.2
 
 [options.packages.find]
 where = src

--- a/src/textual_inputs/__init__.py
+++ b/src/textual_inputs/__init__.py
@@ -1,6 +1,6 @@
 from .integer_input import IntegerInput
 from .text_input import TextInput
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["IntegerInput", "TextInput"]


### PR DESCRIPTION
- changes in textual 0.1.11 break the form example's message handlers
- update version of textual to minimum 0.1.11
- update message handlers from message_ to handle_
- bump version of textual-inputs to 0.2.2

Closes #17 