### PR TITLE
fix: patch for kwargs error

### DIFF
--- a/src/textual_inputs/__init__.py
+++ b/src/textual_inputs/__init__.py
@@ -1,6 +1,6 @@
 from .integer_input import IntegerInput
 from .text_input import TextInput
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = ["IntegerInput", "TextInput"]

--- a/src/textual_inputs/integer_input.py
+++ b/src/textual_inputs/integer_input.py
@@ -79,9 +79,8 @@ class IntegerInput(Widget):
         placeholder: Union[str, int] = "",
         title: str = "",
         step: int = 1,
-        **kwargs: Any
     ) -> None:
-        super().__init__(name, **kwargs)
+        super().__init__(name)
         self.value = value
         self.placeholder = str(placeholder)
         self.title = title

--- a/src/textual_inputs/text_input.py
+++ b/src/textual_inputs/text_input.py
@@ -81,9 +81,8 @@ class TextInput(Widget):
         placeholder: str = "",
         title: str = "",
         password: bool = False,
-        **kwargs: Any,
     ) -> None:
-        super().__init__(name, **kwargs)
+        super().__init__(name)
         self.value = value
         self.placeholder = placeholder
         self.title = title


### PR DESCRIPTION
- remove kwargs from TextInput and IntegerInput init
- textual Widget supports only the name parameter in its init so passing style="blue" would cause an error.

Closes #19 