### PR TITLE
Update TextInput to handle text overflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ python examples/simple_form.py
 ### TextInput 🔡
 
 - value - string
-- one line of text
+- one line of text with overflow support
 - placeholder and title support
 - password mode to hide input
 - syntax mode to highlight code

--- a/src/textual_inputs/text_input.py
+++ b/src/textual_inputs/text_input.py
@@ -37,8 +37,7 @@ def syntax_highlight_text(code: str, syntax: str) -> Text:
 
 
 class TextInput(Widget):
-    """
-    A simple text input widget.
+    """A simple text input widget.
 
     Args:
         name (Optional[str]): The unique name of the widget. If None, the
@@ -50,10 +49,10 @@ class TextInput(Widget):
             of the widget's border.
         password (bool, optional): Defaults to False. Hides the text
             input, replacing it with bullets.
-        syntax (Optional[str]): the name of the language for syntax highlighting.
+        syntax (Optional[str]): The name of the language for syntax highlighting.
 
     Attributes:
-        value (str): the value of the text field
+        value (str): The value of the text field
         placeholder (str): The placeholder message.
         title (str): The displayed title of the widget.
         has_password (bool): True if the text field masks the input.
@@ -61,10 +60,10 @@ class TextInput(Widget):
         has_focus (bool): True if the widget is focused.
         cursor (Tuple[str, Style]): The character used for the cursor
             and a rich Style object defining its appearance.
-        on_change_handler_name (str): name of handler function to be
+        on_change_handler_name (str): The name of handler function to be
             called when an on change event occurs. Defaults to
             handle_input_on_change.
-        on_focus_handler_name (name): name of handler function to be
+        on_focus_handler_name (name): The name of handler function to be
             called when an on focus event occurs. Defaults to
             handle_input_on_focus.
 
@@ -95,6 +94,7 @@ class TextInput(Widget):
             bold=True,
         ),
     )
+    """Character and style of the cursor."""
     _cursor_position: Reactive[int] = Reactive(0)
     _has_focus: Reactive[bool] = Reactive(False)
 
@@ -111,10 +111,18 @@ class TextInput(Widget):
     ) -> None:
         super().__init__(name)
         self.value = value
+        """The value of the text field"""
         self.placeholder = placeholder
+        """
+        Text that appears in the widget when value is "" and the widget
+        is not focused.
+        """
         self.title = title
+        """The displayed title of the widget."""
         self.has_password = password
+        """True if the text field masks the input."""
         self.syntax = syntax
+        """The name of the language for syntax highlighting."""
         self._on_change_message_class = InputOnChange
         self._on_focus_message_class = InputOnFocus
         self._cursor_position = len(self.value)
@@ -201,9 +209,7 @@ class TextInput(Widget):
         )
 
     def _modify_text(self, segment: str) -> Union[str, Text]:
-        """
-        Produces the text with modifications, such as password concealing.
-        """
+        """Produces the text with modifications, such as password concealing."""
         if self.has_password:
             return conceal_text(segment)
         if self.syntax:
@@ -212,10 +218,11 @@ class TextInput(Widget):
 
     @property
     def _visible_width(self):
-        width, _ = self.size
+        """Width in characters of the inside of the input"""
         # remove 2, 1 for each of the border's edges
         # remove 1 more for the cursor
         # remove 2 for the padding either side of the input
+        width, _ = self.size
         if self.border:
             width -= 2
         if self._has_focus:
@@ -224,66 +231,90 @@ class TextInput(Widget):
         return width
 
     def _text_offset_window(self):
+        """
+        Produce the start and end indices of the visible portions of the
+        text value.
+        """
         return self._text_offset, self._text_offset + self._visible_width
 
     def _render_text_with_cursor(self) -> List[Union[str, Text, Tuple[str, Style]]]:
-        """
-        Produces the renderable Text object combining value and cursor
-        """
+        """Produces the renderable Text object combining value and cursor"""
         text = self._modify_text(self.value)
 
         # trim the string to fit within the widgets dimensions
-        # we then need to convert the cursor to be relative to this view
         left, right = self._text_offset_window()
         text = text[left:right]
+
+        # convert the cursor to be relative to this view
         cursor_relative_position = self._cursor_position - self._text_offset
         return [
-            text[: cursor_relative_position],
+            text[:cursor_relative_position],
             self.cursor,
-            text[cursor_relative_position :],
+            text[cursor_relative_position:],
         ]
 
     async def on_focus(self, event: events.Focus) -> None:
+        """Handle Focus events
+
+        Args:
+            event (events.Focus): A Textual Focus event
+        """
         self._has_focus = True
         await self._emit_on_focus()
 
     async def on_blur(self, event: events.Blur) -> None:
+        """Handle Blur events
+
+        Args:
+            event (events.Blur): A Textual Blur event
+        """
         self._has_focus = False
 
     def _update_offset_left(self):
-        # ensure the cursor always has at least N character to the left
+        """
+        Decrease the text offset if the cursor moves less than 3 characters
+        from the left edge. This will shift the text to the right and keep
+        the cursor 3 characters from the left edge. If the text offset is 0
+        then the cursor may continue to move until it reaches the left edge.
+        """
         visibility_left = 3
         if self._cursor_position < self._text_offset + visibility_left:
-            # move the text offset to permit the cursor at the end
             self._text_offset = max(0, self._cursor_position - visibility_left)
 
     def _update_offset_right(self):
+        """
+        Increase the text offset if the cursor moves beyond the right
+        edge of the widget. This will shift the text left and make the
+        cursor visible at the right edge of the widget.
+        """
         _, right = self._text_offset_window()
-        # if we're at the edge of the widget
-        # shuffle our text across
         if self._cursor_position > right:
-            # move the text offset to permit the cursor at the end
             self._text_offset = self._cursor_position - self._visible_width
 
-    def cursor_left(self):
+    def _cursor_left(self):
+        """Handle key press Left"""
         if self._cursor_position > 0:
             self._cursor_position -= 1
             self._update_offset_left()
 
-    def cursor_right(self):
+    def _cursor_right(self):
+        """Handle key press Right"""
         if self._cursor_position < len(self.value):
             self._cursor_position = self._cursor_position + 1
             self._update_offset_right()
 
-    def cursor_home(self):
+    def _cursor_home(self):
+        """Handle key press Home"""
         self._cursor_position = 0
         self._update_offset_left()
 
-    def cursor_end(self):
+    def _cursor_end(self):
+        """Handle key press End"""
         self._cursor_position = len(self.value)
         self._update_offset_right()
 
-    def key_backspace(self):
+    def _key_backspace(self):
+        """Handle key press Backspace"""
         if self._cursor_position > 0:
             self.value = (
                 self.value[: self._cursor_position - 1]
@@ -292,14 +323,16 @@ class TextInput(Widget):
             self._cursor_position -= 1
             self._update_offset_left()
 
-    def key_delete(self):
+    def _key_delete(self):
+        """Handle key press Delete"""
         if self._cursor_position < len(self.value):
             self.value = (
                 self.value[: self._cursor_position]
                 + self.value[self._cursor_position + 1 :]
             )
 
-    def key_printable(self, event):
+    def _key_printable(self, event: events.Key):
+        """Handle all printable keys"""
         self.value = (
             self.value[: self._cursor_position]
             + event.key
@@ -311,28 +344,35 @@ class TextInput(Widget):
             self._update_offset_right()
 
     async def on_key(self, event: events.Key) -> None:
+        """Handle key events
+
+        Args:
+            event (events.Key): A Textual Key event
+        """
         BACKSPACE = "ctrl+h"
         if event.key == "left":
-            self.cursor_left()
+            self._cursor_left()
         elif event.key == "right":
-            self.cursor_right()
+            self._cursor_right()
         elif event.key == "home":
-            self.cursor_home()
+            self._cursor_home()
         elif event.key == "end":
-            self.cursor_end()
+            self._cursor_end()
         elif event.key == BACKSPACE:
-            self.key_backspace()
+            self._key_backspace()
             await self._emit_on_change(event)
         elif event.key == "delete":
-            self.key_delete()
+            self._key_delete()
             await self._emit_on_change(event)
         elif len(event.key) == 1 and event.key.isprintable():
-            self.key_printable(event)
+            self._key_printable(event)
             await self._emit_on_change(event)
 
     async def _emit_on_change(self, event: events.Key) -> None:
+        """Emit custom message class on Change events"""
         event.stop()
         await self.emit(self._on_change_message_class(self))
 
     async def _emit_on_focus(self) -> None:
+        """Emit custom message class on Focus events"""
         await self.emit(self._on_focus_message_class(self))


### PR DESCRIPTION
This modifies TextInput to handle arbitrarily large inputs
that previously would overflow off the terminal and
become unreadable.
Add a _text_offset value which records the current
left index of the viewable space.
Change the key handling code to be more modular and
remove redundant code paths which end up with the
same result.
Add _text_offset updating in the key handling code.

There may be better ways of handling some of this, ie `_visible_width`.